### PR TITLE
Center logo in headers

### DIFF
--- a/developer.html
+++ b/developer.html
@@ -4,11 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Developer | Black Forest Hollow</title>
+  <link rel="icon" type="image/svg+xml" href="logo.svg">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <header>
-    <h1>Black Forest Hollow</h1>
+    <div class="header-branding">
+      <img src="logo.svg" alt="Black Forest Hollow logo" class="logo">
+      <h1>Black Forest Hollow</h1>
+    </div>
     <nav>
       <a href="index.html">Home</a>
       <a href="games.html">Games</a>

--- a/games.html
+++ b/games.html
@@ -4,11 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Games | Black Forest Hollow</title>
+  <link rel="icon" type="image/svg+xml" href="logo.svg">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <header>
-    <h1>Black Forest Hollow</h1>
+    <div class="header-branding">
+      <img src="logo.svg" alt="Black Forest Hollow logo" class="logo">
+      <h1>Black Forest Hollow</h1>
+    </div>
     <nav>
       <a href="index.html">Home</a>
       <a href="games.html">Games</a>

--- a/index.html
+++ b/index.html
@@ -4,11 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Black Forest Hollow</title>
+  <link rel="icon" type="image/svg+xml" href="logo.svg">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <header>
-    <h1>Black Forest Hollow</h1>
+    <div class="header-branding">
+      <img src="logo.svg" alt="Black Forest Hollow logo" class="logo">
+      <h1>Black Forest Hollow</h1>
+    </div>
     <nav>
       <a href="index.html">Home</a>
       <a href="games.html">Games</a>

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#111"/>
+  <polygon points="32,8 16,40 48,40" fill="#88ffaa"/>
+  <rect x="28" y="40" width="8" height="16" fill="#88ffaa"/>
+</svg>

--- a/style.css
+++ b/style.css
@@ -13,6 +13,17 @@ header {
   border-bottom: 1px solid #333;
 }
 
+.header-branding {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.logo {
+  height: 40px;
+}
+
 header h1 {
   margin: 0;
   font-size: 2.5rem;


### PR DESCRIPTION
## Summary
- add `logo.svg`
- add `.header-branding` layout class and `.logo` sizing
- insert site icon and branding container in every page

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888c40ca4688321b4713ee4f3134e85